### PR TITLE
Fix watched files paths for tateru config file

### DIFF
--- a/templates/template-gulp-vanilla/tasks/watch.js
+++ b/templates/template-gulp-vanilla/tasks/watch.js
@@ -32,7 +32,7 @@ module.exports = function watch () {
   watchGulp([
     `src/twig/**/*`,
     `src/translations/**/*`,
-    `config.json`,
+    `tateru.config.json`,
   ], tateru);
 
   watchGulp([


### PR DESCRIPTION
Replace `config.json` with `tateru.config.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the configuration file monitored by the watch task to use a new filename.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->